### PR TITLE
Remove duplicate tooltips

### DIFF
--- a/src/main/java/net/projectiledamage/mixin/ItemStackMixin.java
+++ b/src/main/java/net/projectiledamage/mixin/ItemStackMixin.java
@@ -38,10 +38,14 @@ public class ItemStackMixin {
         if (this.item instanceof IProjectileWeapon) {
             List<Text> list = cir.getReturnValue();
             List<TranslatableText> modifierList = new ArrayList<>();
+            int index = -1;
             for (int i = 0; i < list.size(); i++) {
                 if (list.get(i) instanceof TranslatableText translatableText) {
                     if (translatableText.getKey().startsWith("item.modifiers")) {
                         modifierList.add(translatableText);
+                        if (index == -1) {
+                            index = i;
+                        }
                     }
                     if (modifierList.size() > 1) {
                         list.subList(i-1, list.size()).clear();
@@ -50,7 +54,7 @@ public class ItemStackMixin {
             }
             if (modifierList.size() > 1) {
                 list.removeAll(modifierList);
-                list.add(2, new TranslatableText("item.modifiers.both_hands").formatted(Formatting.GRAY));
+                list.add(index, new TranslatableText("item.modifiers.both_hands").formatted(Formatting.GRAY));
             }
         }
     }

--- a/src/main/java/net/projectiledamage/mixin/ItemStackMixin.java
+++ b/src/main/java/net/projectiledamage/mixin/ItemStackMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
 import net.projectiledamage.api.IProjectileWeapon;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -46,6 +47,10 @@ public class ItemStackMixin {
                         list.subList(i-1, list.size()).clear();
                     }
                 }
+            }
+            if (modifierList.size() > 1) {
+                list.removeAll(modifierList);
+                list.add(2, new TranslatableText("item.modifiers.both_hands").formatted(Formatting.GRAY));
             }
         }
     }

--- a/src/main/java/net/projectiledamage/mixin/ItemStackMixin.java
+++ b/src/main/java/net/projectiledamage/mixin/ItemStackMixin.java
@@ -1,0 +1,52 @@
+package net.projectiledamage.mixin;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.projectiledamage.api.IProjectileWeapon;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Environment(EnvType.CLIENT)
+@Mixin(ItemStack.class)
+public class ItemStackMixin {
+    @Mutable
+    @Final
+    @Shadow
+    private final Item item;
+
+    public ItemStackMixin(Item item) {
+        this.item = item;
+    }
+
+    @Inject(method = "getTooltip", at = @At(value = "RETURN", target = "Ljava/util/List;add(Ljava/lang/Object;)Z"))
+    private void combineTooltip(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir) {
+        if (this.item instanceof IProjectileWeapon) {
+            List<Text> list = cir.getReturnValue();
+            List<TranslatableText> modifierList = new ArrayList<>();
+            for (int i = 0; i < list.size(); i++) {
+                if (list.get(i) instanceof TranslatableText translatableText) {
+                    if (translatableText.getKey().startsWith("item.modifiers")) {
+                        modifierList.add(translatableText);
+                    }
+                    if (modifierList.size() > 1) {
+                        list.subList(i-1, list.size()).clear();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/projectiledamage/lang/en_us.json
+++ b/src/main/resources/assets/projectiledamage/lang/en_us.json
@@ -1,3 +1,4 @@
 {
-  "attribute.name.generic.projectile_damage" : "Projectile Damage"
+  "attribute.name.generic.projectile_damage" : "Projectile Damage",
+  "item.modifiers.both_hands": "When Held:"
 }

--- a/src/main/resources/projectiledamage.mixins.json
+++ b/src/main/resources/projectiledamage.mixins.json
@@ -10,6 +10,7 @@
     "RegistryMixin"
   ],
   "client": [
+    "ItemStackMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/57331134/179115859-447c30e6-29d7-4119-b072-df47971bb32b.png)

After:

![image](https://user-images.githubusercontent.com/57331134/179115885-de7d3a0e-09a2-4472-a40b-594c10ace64f.png)

The "When Held:" message can be changed to anything in the lang file (like "When in Main Hand or Off Hand").

If you'd rather the tooltip only be de-duplicated and not change the wording at all (for better language compatibility), you can just grab the first commit of this PR.